### PR TITLE
Fix dataplex and isLost logic

### DIFF
--- a/connector/bigquery/connector.go
+++ b/connector/bigquery/connector.go
@@ -105,6 +105,10 @@ func (b *BigQueryConnector) ReflectTableAttributeToBigQuery(tableAssets []qdc.Da
 
 		// Update table overview
 		bqTableFQN := fmt.Sprintf("bigquery:%s.%s.%s", projectAsset.Name, datasetAsset.Name, tableAsset.PhysicalName)
+		if !qdc.IsAssetContainsValueAsDescription(tableAsset) {
+			b.Logger.Debug("Skip LookupEntry and Update View because the description of qdc table asset is empty. Project: %s, Dataset: %s, Table: %s ", projectAsset.Name, datasetAsset.Name, tableAsset.PhysicalName)
+			continue
+		}
 		tableAssetEntry, err := b.DataplexRepo.LookupEntry(bqTableFQN, projectAsset.Name, tableMetadata.Location)
 		if err != nil {
 			b.Logger.Error("Failed to LookupEntry.: %s", tableAsset.PhysicalName)

--- a/connector/bigquery/connector.go
+++ b/connector/bigquery/connector.go
@@ -55,6 +55,10 @@ func NewBigqueryConnector(prefixForUpdate, overwriteMode string, logger *logger.
 
 func (b *BigQueryConnector) ReflectDatasetDescToBigQuery(schemaAssets []qdc.Data) error {
 	for _, schemaAsset := range schemaAssets {
+		if schemaAsset.IsLost {
+			b.Logger.Debug("Skip schema update because it is lost in qdc : %s", schemaAsset.PhysicalName)
+			continue
+		}
 		datasetMetadata, err := b.BigQueryRepo.GetDatasetMetadata(schemaAsset.PhysicalName)
 		if err != nil {
 			b.Logger.Error("Failed to GetDatasetMetadata. : %s", schemaAsset.PhysicalName)
@@ -77,6 +81,11 @@ func (b *BigQueryConnector) ReflectTableAttributeToBigQuery(tableAssets []qdc.Da
 	for _, tableAsset := range tableAssets {
 		projectAsset := qdc.GetSpecifiedAssetFromPath(tableAsset, "schema4")
 		datasetAsset := qdc.GetSpecifiedAssetFromPath(tableAsset, "schema3")
+
+		if tableAsset.IsLost {
+			b.Logger.Debug("Skip table update because it is lost in qdc : %s->%s->%s ", projectAsset.Name, datasetAsset.Name, tableAsset.PhysicalName)
+			continue
+		}
 		var metadataToUpdate bq.TableMetadataToUpdate
 
 		tableMetadata, err := b.BigQueryRepo.GetTableMetadata(datasetAsset.Name, tableAsset.PhysicalName)

--- a/connector/denodo/connector.go
+++ b/connector/denodo/connector.go
@@ -138,6 +138,10 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 		d.Logger.Info("Start to update denodo database assets")
 		databaseGlobalID := utils.GetGlobalId(d.CompanyID, d.DenodoHostName, vdpDatabase.DatabaseName, "schema")
 		if qdcDatabaseAsset, ok := qdcRootAssetsMap[databaseGlobalID]; ok {
+			if qdcDatabaseAsset.IsLost {
+				d.Logger.Debug("Skip database update because it is lost in qdc : %s", qdcDatabaseAsset.PhysicalName)
+				continue
+			}
 			if shouldUpdateDenodoVdpDatabase(d.PrefixForUpdate, d.OverwriteMode, vdpDatabase, qdcDatabaseAsset) {
 				descForUpdate := genUpdateString(qdcDatabaseAsset.LogicalName, qdcDatabaseAsset.Description)
 				descWithPrefix := utils.AddPrefixToStringIfNotHas(d.PrefixForUpdate, descForUpdate)
@@ -158,6 +162,10 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 			tableFQN := fmt.Sprint(vdpDatabase.DatabaseName, vdpTableAsset.ViewName)
 			tableGlobalID := utils.GetGlobalId(d.CompanyID, d.DenodoHostName, tableFQN, "table")
 			if qdcTableAsset, ok := qdcTableAssetsMap[tableGlobalID]; ok {
+				if qdcTableAsset.IsLost {
+					d.Logger.Debug("Skip table update because it is lost in qdc : %s", qdcTableAsset.PhysicalName)
+					continue
+				}
 				if shouldUpdateDenodoVdpTable(d.PrefixForUpdate, d.OverwriteMode, vdpTableAsset, qdcTableAsset) {
 					descForUpdate := genUpdateString(qdcTableAsset.LogicalName, qdcTableAsset.Description)
 					descWithPrefix := utils.AddPrefixToStringIfNotHas(d.PrefixForUpdate, descForUpdate)
@@ -178,6 +186,10 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 			columnFQN := fmt.Sprint(vdpDatabase.DatabaseName, vdpColumnAsset.ViewName, vdpColumnAsset.ColumnName)
 			columnGlobalID := utils.GetGlobalId(d.CompanyID, d.DenodoHostName, columnFQN, "column")
 			if qdcColumnAsset, ok := qdcColumnAssetsMap[columnGlobalID]; ok {
+				if qdcColumnAsset.IsLost {
+					d.Logger.Debug("Skip column update because it is lost in qdc : %s", qdcColumnAsset.PhysicalName)
+					continue
+				}
 				if vdpColumnAsset.ViewType != 1 {
 					d.Logger.Debug("Skip update view. only derived view will be updated. database name: %s, table name: %s column name: %s", vdpColumnAsset.DatabaseName, vdpColumnAsset.ViewName, vdpColumnAsset.ColumnName)
 					continue

--- a/connector/glue/connector.go
+++ b/connector/glue/connector.go
@@ -60,6 +60,11 @@ func (g *GlueConnector) ReflectDatabaseDescToAthena(dbAssets []qdc.Data) error {
 	mapDBAssetByDBName := mapDBAssetByDBName(allGlueDBs)
 
 	for _, dbAsset := range dbAssets {
+		if dbAsset.IsLost {
+			g.Logger.Debug("Skip schema update because it is lost in qdc : %s", dbAsset.PhysicalName)
+			continue
+		}
+
 		if glueDB, ok := mapDBAssetByDBName[dbAsset.PhysicalName]; ok {
 			updateDatabaseInput := genUpdateDatabaseInput(glueDB)
 
@@ -106,6 +111,11 @@ func (g *GlueConnector) ReflectTableAttributeToAthena(tableAssets []qdc.Data) er
 	for _, tableAsset := range tableAssets {
 		tableShouldBeUpdated := false
 		databaseAsset := qdc.GetSpecifiedAssetFromPath(tableAsset, "schema3")
+
+		if tableAsset.IsLost {
+			g.Logger.Debug("Skip table update because it is lost in qdc : %s->%s", databaseAsset.Name, tableAsset.PhysicalName)
+			continue
+		}
 
 		glueTable, err := g.GlueRepo.GetTable(g.AthenaAccountID, databaseAsset.Name, tableAsset.PhysicalName)
 		if err != nil {


### PR DESCRIPTION
# Description
To reduce the amount of API call, I added the following updates.
  - To check the description attribute on qdcAsset and if the value is empty string, skip Dataplex read API.
  - To process the only assets exist in QDC.

