### PR TITLE
Fix capital letter case, permission problem

### DIFF
--- a/connector/denodo/connector.go
+++ b/connector/denodo/connector.go
@@ -147,7 +147,11 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 				descWithPrefix := utils.AddPrefixToStringIfNotHas(d.PrefixForUpdate, descForUpdate)
 				err := d.DenodoDBClient.UpdateVdpDatabaseDesc(vdpDatabase.DatabaseName, descWithPrefix)
 				if err != nil {
-					return err
+					if isPrivilegesErr(err.Error()) {
+						d.Logger.Warning("Failed to update DB due to permission problem. Error: %s, DB Name: %s", err.Error(), vdpDatabase.DatabaseName)
+					} else {
+						return err
+					}
 				}
 				d.Logger.Debug("Updated database description. database name: %s.", vdpDatabase.DatabaseName)
 			}
@@ -161,6 +165,7 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 		for _, vdpTableAsset := range vdpTableAssets {
 			tableFQN := fmt.Sprint(vdpDatabase.DatabaseName, vdpTableAsset.ViewName)
 			tableGlobalID := utils.GetGlobalId(d.CompanyID, d.DenodoHostName, tableFQN, "table")
+			d.Logger.Debug("Will update table if condition is true. GlobalID: %s. DBName: %s TableName: %s ", tableGlobalID, vdpTableAsset.DatabaseName, vdpTableAsset.ViewName)
 			if qdcTableAsset, ok := qdcTableAssetsMap[tableGlobalID]; ok {
 				if qdcTableAsset.IsLost {
 					d.Logger.Debug("Skip table update because it is lost in qdc : %s", qdcTableAsset.PhysicalName)
@@ -171,7 +176,11 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 					descWithPrefix := utils.AddPrefixToStringIfNotHas(d.PrefixForUpdate, descForUpdate)
 					err := d.DenodoDBClient.UpdateVdpTableDesc(vdpTableAsset, descWithPrefix)
 					if err != nil {
-						return err
+						if isPrivilegesErr(err.Error()) {
+							d.Logger.Warning("Failed to update Table due to permission problem. Error: %s, DB Name: %s Table Name: %s", err.Error(), vdpTableAsset.DatabaseName, vdpTableAsset.ViewName)
+						} else {
+							return err
+						}
 					}
 					d.Logger.Debug("Updated table description. database name: %s. table name: %s", vdpTableAsset.DatabaseName, vdpTableAsset.ViewName)
 				}
@@ -195,11 +204,16 @@ func (d *DenodoConnector) ReflectVdpMetadataToDataCatalog(qdcRootAssetsMap, qdcT
 					continue
 				}
 				if shouldUpdateDenodoVdpColumn(d.PrefixForUpdate, d.OverwriteMode, vdpColumnAsset, qdcColumnAsset) {
+					d.Logger.Debug("Will update column. GlobalID: %s. DBName: %s TableName: %s ColumnName: %s", columnGlobalID, vdpColumnAsset.DatabaseName, vdpColumnAsset.ViewName, vdpColumnAsset.ColumnName)
 					descForUpdate := genUpdateString(qdcColumnAsset.LogicalName, qdcColumnAsset.Description)
 					descWithPrefix := utils.AddPrefixToStringIfNotHas(d.PrefixForUpdate, descForUpdate)
 					err := d.DenodoDBClient.UpdateVdpTableColumnDesc(vdpColumnAsset, descWithPrefix)
 					if err != nil {
-						return err
+						if isPrivilegesErr(err.Error()) {
+							d.Logger.Warning("Failed to update Column due to permission problem. Error: %s, DB Name: %s Table Name: %s Column Name: %s", err.Error(), vdpColumnAsset.DatabaseName, vdpColumnAsset.ViewName, vdpColumnAsset.ColumnName)
+						} else {
+							return err
+						}
 					}
 					d.Logger.Debug("Updated column description. database name: %s. table name: %s. column name: %s", vdpColumnAsset.DatabaseName, vdpColumnAsset.ViewName, vdpColumnAsset.ColumnName)
 				}
@@ -323,4 +337,8 @@ func getFilteredRootAssets(targetDBs []string, qdcRootAssets []qdc.Data) []qdc.D
 		targetRootAssets = qdcRootAssets
 	}
 	return targetRootAssets
+}
+
+func isPrivilegesErr(errMessage string) bool {
+	return strings.Contains(errMessage, "The user does not have enough privileges")
 }

--- a/connector/denodo/connector_internal_test.go
+++ b/connector/denodo/connector_internal_test.go
@@ -1115,3 +1115,33 @@ func TestFilterRootAsset(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrivilegesErr(t *testing.T) {
+	testCases := []struct {
+		Input  string
+		Expect bool
+	}{
+		{
+			Input:  "",
+			Expect: false,
+		},
+		{
+			Input:  "xxx",
+			Expect: false,
+		},
+		{
+			Input:  "Failed to ReflectMetadataToDataCatalog, UpdateVdpDatabaseDesc failed Query Execution failed pq: error modifying database: The user does not have enough privileges or does not have ADMIN privileges",
+			Expect: true,
+		},
+		{
+			Input:  "Failed to ReflectMetadataToDataCatalog,The user does not have enough privileges or does not have ADMIN privileges",
+			Expect: true,
+		},
+	}
+	for _, testCase := range testCases {
+		res := isPrivilegesErr(testCase.Input)
+		if !reflect.DeepEqual(res, testCase.Expect) {
+			t.Errorf("want %+v but got %+v", testCase.Expect, res)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func runReverseAgent(systemName *string) error {
 		logger.Info("Start to run ReflectMetadataToDataCatalog.")
 		err = DenodoConnector.ReflectMetadataToDataCatalog()
 		if err != nil {
-			logger.Error("Failed to ReflectMetadataToDataCatalog")
+			logger.Error("Failed to ReflectMetadataToDataCatalog, %s", err.Error())
 			return fmt.Errorf("Failed to ReflectMetadataToDataCatalog for Denodo")
 		}
 	default:

--- a/repository/denodo/odbc/odbc.go
+++ b/repository/denodo/odbc/odbc.go
@@ -147,7 +147,7 @@ func (c *Client) UpdateVdpTableDesc(getViewResult models.GetViewsResult, descrip
 
 func (c *Client) UpdateVdpTableColumnDesc(getViewColumnResult models.GetViewColumnsResult, description string) error {
 	alterTableTarget := getAlterViewType(getViewColumnResult.ViewType)
-	alterStatement := fmt.Sprintf(`alter %s %s (alter column %s add (description = '%s'))`,
+	alterStatement := fmt.Sprintf("alter %s %s (alter column `%s` add (description = '%s'))",
 		alterTableTarget,
 		getViewColumnResult.ViewName,
 		getViewColumnResult.ColumnName,
@@ -155,7 +155,7 @@ func (c *Client) UpdateVdpTableColumnDesc(getViewColumnResult models.GetViewColu
 	)
 	err := c.ExecuteQuery(alterStatement)
 	if err != nil {
-		return fmt.Errorf("UpdateVdpTableColumnDesc failed %s", err)
+		return fmt.Errorf("UpdateVdpTableColumnDesc failed error: %s. query: %s", err, alterStatement)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description
- Enclosed column name with "`" because the query will fail if the column name is capital letter case.
- Added error handling for permission problem.